### PR TITLE
Syntax error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ class role_nexus_server {
   Class['::java'] ->
   Group[$nexus_group] ->
   User[$nexus_user] ->
-  Class['::nexus'] ->
+  Class['::nexus']
 ```
 
 ### Nginx proxy


### PR DESCRIPTION
If this example is used as is, it will cause a syntax error.
