### PR TITLE
updated module to be able to deal with changes in download archive structure at sonatype ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,35 +14,38 @@ download link and determining the name of the nexus directory.
 
 ```puppet
 class role_nexus_server {
-  
+
+  $nexus_group='nexus'
+  $nexus_user='nexus'
   # puppetlabs-java
   # NOTE: Nexus requires
   class{ '::java':
-    distribution => 'java-1.7.0-openjdk'
+    distribution => 'jdk'
   }
 
-  group{ 'nexus':
+  group{ $nexus_group:
     ensure => present,
     system => true
   }
 
-  user{ 'nexus':
+  user{ $nexus_user:
     ensure => present,
     comment => 'Nexus user',
-    gid     => 'nexus',
-    home    => '/srv/nexus',
+    gid     => $nexus_group,
+    home    => '/opt/nexus',
     shell   => '/bin/bash', # unfortunately required to start application via script.
     system  => true,
-    require => Group['nexus']
+    require => Group[$nexus_group]
   }
 
   class{ '::nexus':
-    version        => '2.6.2',
-    nexus_user     => 'nexus',
-    nexus_group    => 'nexus'
-    nexus_root     => '/srv', # All directories and files will be relative to this
+    version             => '2.7.0',
+    revision_in_archive => '06',
+    nexus_user          => $nexus_user,
+    nexus_group         => $nexus_group,
+    nexus_root          => '/opt', # All directories and files will be relative to this
   }
-  
+
   Class['::java'] ->
   Group[$nexus_group] ->
   User[$nexus_user] ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,14 +30,15 @@
 # Copyright 2013 Hubspot
 #
 class nexus (
-  $version        = $nexus::params::version,
-  $revision       = $nexus::params::revision,
-  $nexus_root     = $nexus::params::nexus_root,
-  $nexus_home_dir = $nexus::params::nexus_home_dir,
-  $nexus_user     = $nexus::params::nexus_user,
-  $nexus_group    = $nexus::params::nexus_group,
-  $nexus_host     = $nexus::params::nexus_host,
-  $nexus_port     = $nexus::params::nexus_port,
+  $version             = $nexus::params::version,
+  $revision            = undef,
+  $revision_in_archive = undef,
+  $nexus_root          = $nexus::params::nexus_root,
+  $nexus_home_dir      = $nexus::params::nexus_home_dir,
+  $nexus_user          = $nexus::params::nexus_user,
+  $nexus_group         = $nexus::params::nexus_group,
+  $nexus_host          = $nexus::params::nexus_host,
+  $nexus_port          = $nexus::params::nexus_port,
 ) inherits nexus::params {
   include stdlib
 
@@ -51,14 +52,15 @@ class nexus (
   anchor{ 'nexus::begin':}
 
   class{ 'nexus::package':
-    version        => $version,
-    revision       => $revision,
-    nexus_root     => $nexus_root,
-    nexus_home_dir => $nexus_home_dir,
-    nexus_user     => $nexus_user,
-    nexus_group    => $nexus_group,
-    require        => Anchor['nexus::begin'],
-    notify         => Class['nexus::service']
+    version             => $version,
+    revision            => $revision,
+    revision_in_archive => $revision_in_archive,
+    nexus_root          => $nexus_root,
+    nexus_home_dir      => $nexus_home_dir,
+    nexus_user          => $nexus_user,
+    nexus_group         => $nexus_group,
+    require             => Anchor['nexus::begin'],
+    notify              => Class['nexus::service']
   }
 
   class{ 'nexus::config':

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -30,6 +30,7 @@
 class nexus::package (
   $version,
   $revision,
+  $revision_in_archive,
   $nexus_root,
   $nexus_home_dir,
   $nexus_user,
@@ -40,12 +41,21 @@ class nexus::package (
   $nexus_home      = "${nexus_root}/${nexus_home_dir}"
   $nexus_work      = "${nexus_root}/${nexus::params::nexus_work_dir}"
 
-  $full_version    = "${version}-${revision}"
+  if ($revision == undef or $revision == '') {
+     $full_version    = "${version}"
+  } else {
+     $full_version    ="${version}-${revision}"	
+  }
+  if ($revision_in_archive == undef or $revision_in_archive == '') {
+     $home_dir_version    = "${version}"
+  } else {
+     $home_dir_version    ="${version}-${revision_in_archive}"	
+  }
 
   $nexus_archive   = "nexus-${full_version}-bundle.tar.gz"
   $download_url    = "${download_site}/${nexus_archive}"
   $dl_file         = "${nexus_root}/${nexus_archive}"
-  $nexus_home_real = "${nexus_root}/nexus-${full_version}"
+  $nexus_home_real = "${nexus_root}/nexus-${home_dir_version}"
 
   # NOTE: When setting version to 'latest' the site redirects to the latest
   # release. But, nexus-latest-bundle.tar.gz will already exist and

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@
 class nexus::params {
   # See nexus::package on why this won't increment the package version.
   $version        = 'latest'
-  $revision       = '01'
+  #$revision       = '01'
   $download_site  = 'http://www.sonatype.org/downloads'
   $nexus_root     = '/srv'
   $nexus_home_dir = 'nexus'


### PR DESCRIPTION
... and improved README example puppet manifest:
- as distribution only jre and jdk are allowed when using puppetlabs/java
- unified usage of variables $nexus_group and $nexus_user in README example
- changed default $revision to undef ($revision is used to compose the download url)
- added $revsion_in_archive to support archives such as nexus-2.7.0-bundle-tar.gz, in which the root directory is not nexus-2.7.0 but nexus-2.7.0-06 (see http://www.sonatype.org/nexus/archived)
