### PR TITLE
Executable wrapper for linux

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -93,9 +93,13 @@ class nexus::package (
   case $::osfamily {
     'RedHat', 'Linux': {
       file{"${nexus_home}/bin/jsw/linux-x86-32/wrapper":
-        mode => '0754'
+        owner => $nexus_user,
+        group => $nexus_group,
+        mode  => '0754'
       }
       file{"${nexus_home}/bin/jsw/linux-x86-64/wrapper":
+        owner => $nexus_user,
+        group => $nexus_group,
         mode => '0754'
       }
     }


### PR DESCRIPTION
I found when using Nexus in linux, I had to change the permission level in order to make wrapper executable.
