### PR TITLE
explicitly tells puppet not to manage the mode

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -73,7 +73,8 @@ class nexus::package (
     owner   => $nexus_user,
     group   => $nexus_group,
     recurse => true,
-    require => Exec[ 'nexus-untar']
+    require => Exec[ 'nexus-untar'],
+    mode    => undef
   }
 
   file{ $nexus_work:
@@ -81,12 +82,14 @@ class nexus::package (
     owner   => $nexus_user,
     group   => $nexus_group,
     recurse => true,
-    require => Exec[ 'nexus-untar']
+    require => Exec[ 'nexus-untar'],
+    mode    => undef
   }
 
   file{ $nexus_home:
     ensure  => link,
     target  => $nexus_home_real,
-    require => Exec['nexus-untar']
+    require => Exec['nexus-untar'],
+    mode    => undef
   }
 }


### PR DESCRIPTION
As a follow up to #6, I am submitting this small change that explicitly tells puppet not to manage the file permissions of the expanded tar file.

This is specifically a work around to an issue I have where my company for whatever reason sets a global override.
