### PR TITLE
Added an option to manage the files in the work dir

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,17 +30,18 @@
 # Copyright 2013 Hubspot
 #
 class nexus (
-  $version           = $nexus::params::version,
-  $revision          = $nexus::params::revision,
-  $download_site     = $nexus::params::download_site,
-  $nexus_root        = $nexus::params::nexus_root,
-  $nexus_home_dir    = $nexus::params::nexus_home_dir,
-  $nexus_user        = $nexus::params::nexus_user,
-  $nexus_group       = $nexus::params::nexus_group,
-  $nexus_host        = $nexus::params::nexus_host,
-  $nexus_port        = $nexus::params::nexus_port,
-  $nexus_context     = $nexus::params::nexus_context,
-  $manage_nexus_user = $nexus::params::manage_nexus_user,
+  $version            = $nexus::params::version,
+  $revision           = $nexus::params::revision,
+  $download_site      = $nexus::params::download_site,
+  $nexus_root         = $nexus::params::nexus_root,
+  $nexus_home_dir     = $nexus::params::nexus_home_dir,
+  $nexus_user         = $nexus::params::nexus_user,
+  $nexus_group        = $nexus::params::nexus_group,
+  $nexus_host         = $nexus::params::nexus_host,
+  $nexus_port         = $nexus::params::nexus_port,
+  $nexus_work_recurse = $nexus::params::nexus_work_dir_recurse,
+  $nexus_context      = $nexus::params::nexus_context,
+  $manage_nexus_user  = $nexus::params::manage_nexus_user,
 ) inherits nexus::params {
   include stdlib
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -35,6 +35,7 @@ class nexus::package (
   $nexus_home_dir,
   $nexus_user,
   $nexus_group,
+  $nexus_work_recurse,
 ) inherits nexus::params {
 
   $nexus_home      = "${nexus_root}/${nexus_home_dir}"
@@ -80,7 +81,7 @@ class nexus::package (
     ensure  => directory,
     owner   => $nexus_user,
     group   => $nexus_group,
-    recurse => true,
+    recurse => $nexus_work_recurse,
     require => Exec[ 'nexus-untar']
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,16 +21,17 @@
 #
 class nexus::params {
   # See nexus::package on why this won't increment the package version.
-  $version        = 'latest'
-  $revision       = '01'
-  $download_site  = 'http://www.sonatype.org/downloads'
-  $nexus_root     = '/srv'
-  $nexus_home_dir = 'nexus'
-  $nexus_work_dir = 'sonatype-work'
-  $nexus_user     = 'nexus'
-  $nexus_group    = 'nexus'
-  $nexus_host     = '0.0.0.0'
-  $nexus_port     = '8081'
-  $nexus_context  = '/nexus'
-  $manage_nexus_user = true
+  $version                = 'latest'
+  $revision               = '01'
+  $download_site          = 'http://www.sonatype.org/downloads'
+  $nexus_root             = '/srv'
+  $nexus_home_dir         = 'nexus'
+  $nexus_work_dir         = 'sonatype-work'
+  $nexus_work_dir_recurse = true
+  $nexus_user             = 'nexus'
+  $nexus_group            = 'nexus'
+  $nexus_host             = '0.0.0.0'
+  $nexus_port             = '8081'
+  $nexus_context          = '/nexus'
+  $manage_nexus_user      = true
 }


### PR DESCRIPTION
Hello and thanks for your module, in my environment I found puppet agent to hung while eating a lot of memory .

With a strace i discovered that it was reading all my nexus_work directory (that contains around 200K files) and this was "killing" the puppet agent run.

So I've added an option ( nexus_work_recurse) to be able to choose to manage recursively all the files in the work dir, on systems with a lot of files probably you want this to false, I've left the default to true, so it should be fully compatible with the past.
