### PR TITLE
Make sure that the nexus_root directory exist

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -66,7 +66,16 @@ class nexus (
       shell      => '/bin/sh', # required to start application via script.
       system     => true,
       require    => Group['nexus']
+    } ->
+
+    file { $nexus_root:
+      ensure => present,
+      path   => $nexus_root,
+      owner  => $nexus_user,
+      group  => $nexus_group,
+      mode   => '0755'
     }
+
   }
 
   class{ 'nexus::package':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,7 +69,7 @@ class nexus (
     } ->
 
     file { $nexus_root:
-      ensure => present,
+      ensure => directory,
       path   => $nexus_root,
       owner  => $nexus_user,
       group  => $nexus_group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,8 +49,6 @@ class nexus (
     fail('Cannot set version nexus version to "latest" or leave undefined.')
   }
 
-
-
   anchor{ 'nexus::begin':}
 
   if($nexus_manage_user){
@@ -66,14 +64,17 @@ class nexus (
       shell      => '/bin/sh', # required to start application via script.
       system     => true,
       require    => Group['nexus']
-    } ->
+    }
 
-    file { $nexus_root:
-      ensure => directory,
-      path   => $nexus_root,
-      owner  => $nexus_user,
-      group  => $nexus_group,
-      mode   => '0755'
+
+    if ($nexus_root != $nexus::params::nexus_root) {
+      file { $nexus_root:
+        ensure => directory,
+        path   => $nexus_root,
+        owner  => $nexus_user,
+        group  => $nexus_group,
+        mode   => '0755'
+      }
     }
 
   }


### PR DESCRIPTION
if the nexus_root directory does not exist (e.g. $nexus_root = '/srv/nexus') then the module fails.

if the nexus_root directory is /srv then nexus logs the exceptions below because it cannot write to the ${user.home} (/srv) that is owned by root. (see this: https://issues.sonatype.org/browse/NEXUS-3671 )

so to avoid that I added logic to make sure the module has this new functionality while at the same time keep backwards compatibility.

