### PR TITLE
Remove recursiveness and create the root folder

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -68,11 +68,17 @@ class nexus::package (
     path    => ['/bin','/usr/bin'],
   }
 
+  file{ $nexus_root:
+    ensure  => directory,
+    owner   => $nexus_user,
+    group   => $nexus_group,
+    require => Exec[ 'nexus-untar' ]
+  }
+
   file{ $nexus_home_real:
     ensure  => directory,
     owner   => $nexus_user,
     group   => $nexus_group,
-    recurse => true,
     require => Exec[ 'nexus-untar']
   }
 
@@ -80,7 +86,6 @@ class nexus::package (
     ensure  => directory,
     owner   => $nexus_user,
     group   => $nexus_group,
-    recurse => true,
     require => Exec[ 'nexus-untar']
   }
 


### PR DESCRIPTION
Recursiveness is a poor way of directory tree structure. Puppet will be fast when it installs nexus, but as you begin to fill your nexus repo with artifacts the puppet run becomes very slow over time.

With recurse on a directory, it ends up checking all the files in that directory.
