### PR TITLE
deprecate $revision parameter.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,10 @@ class nexus (
     fail('Cannot set version nexus version to "latest" or leave undefined.')
   }
 
+  if $revision != 'deprecated' {
+    warning('$revision parameter is deprecated. Sonotype no longer sets this in package names.')
+  }
+
 
 
   anchor{ 'nexus::begin':}
@@ -72,7 +76,6 @@ class nexus (
 
   class{ 'nexus::package':
     version        => $version,
-    revision       => $revision,
     download_site  => $download_site,
     nexus_root     => $nexus_root,
     nexus_home_dir => $nexus_home_dir,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -29,7 +29,6 @@
 #
 class nexus::package (
   $version,
-  $revision,
   $download_site,
   $nexus_root,
   $nexus_home_dir,
@@ -41,12 +40,11 @@ class nexus::package (
   $nexus_home      = "${nexus_root}/${nexus_home_dir}"
   $nexus_work      = "${nexus_work_dir}"
 
-  $full_version    = "${version}-${revision}"
 
-  $nexus_archive   = "nexus-${full_version}-bundle.tar.gz"
+  $nexus_archive   = "nexus-${version}-bundle.tar.gz"
   $download_url    = "${download_site}/${nexus_archive}"
   $dl_file         = "${nexus_root}/${nexus_archive}"
-  $nexus_home_real = "${nexus_root}/nexus-${full_version}"
+  $nexus_home_real = "${nexus_root}/nexus-${version}"
 
   # NOTE: When setting version to 'latest' the site redirects to the latest
   # release. But, nexus-latest-bundle.tar.gz will already exist and

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@
 class nexus::params {
   # See nexus::package on why this won't increment the package version.
   $version        = 'latest'
-  $revision       = '01'
+  $revision       = 'deprecated'
   $download_site  = 'http://www.sonatype.org/downloads'
   $nexus_root     = '/srv'
   $nexus_home_dir = 'nexus'


### PR DESCRIPTION
This is no longer set in file names of packages to download.
