### PR TITLE
Add a base .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.swp
+.ruby-version
+.ruby-gemset
+Gemfile.lock
+pkg


### PR DESCRIPTION
Setup a gitignore to help avoid certain files getting into the repo

- *.swp (vim swap files)
- Gemfile.lock (the lock file created by bundler when using Gemfile)
- pkg (the result director and everything below it used for puppet
  module build)
- .ruby-{version,gemset} (rvm environment files for local gemset & ruby
  that are in use)

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>