### PR TITLE
Fix up the basic initial spec tests

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,7 +58,8 @@ class nexus (
     $real_nexus_work_dir = "${nexus_root}/sonatype-work/nexus"
   }
 
-  anchor{ 'nexus::begin':}
+  anchor{ 'nexus::begin': }
+  anchor{ 'nexus::end': }
 
   if($nexus_manage_user){
     group { $nexus_group :
@@ -87,7 +88,6 @@ class nexus (
     nexus_work_dir        => $real_nexus_work_dir,
     nexus_work_dir_manage => $nexus_work_dir_manage,
     nexus_work_recurse    => $nexus_work_recurse,
-    require               => Anchor['nexus::begin'],
     notify                => Class['nexus::service']
   }
 
@@ -98,17 +98,14 @@ class nexus (
     nexus_port     => $nexus_port,
     nexus_context  => $nexus_context,
     nexus_work_dir => $real_nexus_work_dir,
-    require        => Class['nexus::package'],
     notify         => Class['nexus::service']
   }
 
-  class{ 'nexus::service':
-    nexus_home => "${nexus_root}/${nexus_home_dir}",
-    nexus_user => $nexus_user,
-    require    => Class['nexus::config']
-  }
+  include '::nexus::service'
 
-  anchor{ 'nexus::end':
-    require => Class['nexus::service']
-  }
+  Anchor['nexus::begin'] ->
+    Class['nexus::package'] ->
+    Class['nexus::config'] ->
+    Class['nexus::service'] ->
+  Anchor['nexus::end']
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,7 +101,11 @@ class nexus (
     notify         => Class['nexus::service']
   }
 
-  include '::nexus::service'
+  class { 'nexus::service':
+    nexus_home => "${nexus_root}/${nexus_home_dir}",
+    nexus_user => $nexus_user,
+    version    => $version,
+  }
 
   Anchor['nexus::begin'] ->
     Class['nexus::package'] ->

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,10 +18,11 @@
 #
 # Copyright 2013 Hubspot
 #
-class nexus::service(
-  $nexus_home,
-  $nexus_user
-) inherits nexus::params {
+class nexus::service {
+  # acquire our needed parameters out of the master class
+  $nexus_home = "${::nexus::nexus_root}/${::nexus::nexus_home_dir}"
+  $nexus_user = $::nexus::nexus_user
+  $version = $::nexus::version
 
   $nexus_script = "${nexus_home}/bin/nexus"
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -6,9 +6,24 @@
 #
 # NONE
 #
+# === Variables
+#
+# [*nexus_home*] 
+#   The home location for the service
+#
+# [*nexus_user*]
+#   The user to run the service as
+#
+# [*version*]
+#   The version of nexus
+#
 # === Examples
 #
-# class{ 'nexus::service': }
+# class{ 'nexus::service':
+#   nexus_home => '/srv/nexus',
+#   nexus_user => 'nexus',
+#   version    => '2.8.0',
+# }
 #
 # === Authors
 #
@@ -18,12 +33,11 @@
 #
 # Copyright 2013 Hubspot
 #
-class nexus::service {
-  # acquire our needed parameters out of the master class
-  $nexus_home = "${::nexus::nexus_root}/${::nexus::nexus_home_dir}"
-  $nexus_user = $::nexus::nexus_user
-  $version = $::nexus::version
-
+class nexus::service (
+  $nexus_home,
+  $nexus_user,
+  $version
+) {
   $nexus_script = "${nexus_home}/bin/nexus"
 
   file_line{ 'nexus_NEXUS_HOME':

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,7 +1,26 @@
 require 'spec_helper'
 
-describe 'nexus' do
-  it { should create_class('nexus::package') }
-  it { should create_class('nexus::config') }
-  it { should create_class('nexus::service') }
+describe 'nexus', :type => :class do
+  let(:params) {
+    {
+      'version' => '2.11.2'
+    }
+  }
+
+  context 'no params set' do
+    let(:params) {{}}
+
+    it 'should fail if no version configured' do
+      expect { should compile }.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+             /Cannot set version nexus version to "latest" or leave undefined./)
+    end
+  end
+
+  context 'with a version set' do
+    it { should create_class('nexus::package') }
+    it { should create_class('nexus::config') }
+    it { should create_class('nexus::service') }
+  end
 end
+
+# vim: sw=2 ts=2 sts=2 et :

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -1,5 +1,24 @@
 require 'spec_helper'
 
-describe 'nexus::service' do
+describe 'nexus::service', :type => :class do
+  let(:params) {
+    {
+      'nexus_home' => '/srv/nexus',
+      'nexus_user' => 'nexus',
+      'version'    => '01',
+    }
+  }
+
+  context 'no params set' do
+    let(:params) {{}}
+
+    it 'should fail' do
+      expect { should compile }.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+              /Must pass nexus_home/)
+    end
+  end
+
   it { should contain_service('nexus') }
 end
+
+# vim: sw=2 ts=2 sts=2 et :


### PR DESCRIPTION
Get the original spec tests passing.

This adds in two different spec contexts:

* no params defined for the nexus class
  - this is essentially what the tests were at first but they were
    failing due to not catching the thrown exception

* with a version set and nothing else
  - this is essentially what the tests were trying to basically evaluate
    before my modifications but were failing
  - This required some modifications to nexus::service and a minor
    clean-up of how resources were declared / chained in the base nexus
    class.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>