### PR TITLE
Allow for deployment of Nexus Professional

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ class role_nexus_server {
 }
 ```
 
+NOTE: If you wish to deploy a Nexus Pro server instead of Nexus OSS set
+`deploy_pro => true`
+
 ### Nginx proxy
 The following is setup for using the
 [jfryman/puppet-nginx](https://github.com/jfryman/puppet-nginx) module. Nexus

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,7 @@
 class nexus (
   $version               = $nexus::params::version,
   $revision              = $nexus::params::revision,
+  $deploy_pro            = $nexus::params::deploy_pro,
   $download_site         = $nexus::params::download_site,
   $nexus_root            = $nexus::params::nexus_root,
   $nexus_home_dir        = $nexus::params::nexus_home_dir,
@@ -58,6 +59,23 @@ class nexus (
     $real_nexus_work_dir = "${nexus_root}/sonatype-work/nexus"
   }
 
+  # Determine if Nexus Pro should be deployed instead of OSS
+  validate_bool($deploy_pro)
+  if ($deploy_pro) {
+    if ( $download_site != $nexus::params::download_site) {
+      # Use any download site that was passed in
+      $real_download_site = $download_site
+    } else {
+      # No download site was specifically defined, the default is
+      # incorrect for pro so switch to the correct one
+      $real_download_site = $nexus::params::pro_download_site
+    }
+  } else {
+    # Deploy OSS version. The default download_site, or whatever is
+    # passed in is the correct location to download from
+    $real_download_site = $download_site
+  }
+
   anchor{ 'nexus::begin': }
   anchor{ 'nexus::end': }
 
@@ -80,7 +98,8 @@ class nexus (
   class{ 'nexus::package':
     version               => $version,
     revision              => $revision,
-    download_site         => $download_site,
+    deploy_pro            => $deploy_pro,
+    download_site         => $real_download_site,
     nexus_root            => $nexus_root,
     nexus_home_dir        => $nexus_home_dir,
     nexus_user            => $nexus_user,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -30,6 +30,7 @@
 class nexus::package (
   $version,
   $revision,
+  $deploy_pro,
   $download_site,
   $nexus_root,
   $nexus_home_dir,
@@ -44,10 +45,16 @@ class nexus::package (
 
   $full_version = "${version}-${revision}"
 
-  $nexus_archive   = "nexus-${version}-bundle.tar.gz"
+  if ($deploy_pro) {
+    $bundle_type = '-professional'
+  } else {
+    $bundle_type = ''
+  }
+
+  $nexus_archive   = "nexus${bundle_type}-${full_version}-bundle.tar.gz"
   $download_url    = "${download_site}/${nexus_archive}"
   $dl_file         = "${nexus_root}/${nexus_archive}"
-  $nexus_home_real = "${nexus_root}/nexus-${full_version}"
+  $nexus_home_real = "${nexus_root}/nexus${bundle_type}-${full_version}"
 
   # NOTE: When setting version to 'latest' the site redirects to the latest
   # release. But, nexus-latest-bundle.tar.gz will already exist and

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class nexus::params {
   # See nexus::package on why this won't increment the package version.
   $version               = 'latest'
   $revision              = '01'
+  $deploy_pro            = false
   $download_site         = 'http://download.sonatype.com/nexus/oss'
   $nexus_root            = '/srv'
   $nexus_home_dir        = 'nexus'
@@ -34,4 +35,5 @@ class nexus::params {
   $nexus_port            = '8081'
   $nexus_context         = '/nexus'
   $nexus_manage_user     = true
+  $pro_download_site     = 'http://download.sonatype.com/nexus/professional-bundle'
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -20,6 +20,19 @@ describe 'nexus', :type => :class do
     it { should create_class('nexus::package') }
     it { should create_class('nexus::config') }
     it { should create_class('nexus::service') }
+
+    it 'should handle deploy_pro' do
+      params.merge!(
+        {
+          'deploy_pro' => true,
+        }
+      )
+
+      should create_class('nexus::package').with(
+        'deploy_pro'    => true,
+        'download_site' => 'http://download.sonatype.com/nexus/professional-bundle',
+      )
+    end
   end
 end
 

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+describe 'nexus::package', :type => :class do
+  let(:params) {
+    {
+      'deploy_pro'            => false,
+      'download_site'         => 'http://download.sonatype.com/nexus/oss',
+      'nexus_root'            => '/srv',
+      'nexus_home_dir'        => 'nexus',
+      'nexus_user'            => 'nexus',
+      'nexus_group'           => 'nexus',
+      'nexus_work_dir'        => '/srv/sonatype-work/nexus',
+      'nexus_work_dir_manage' => true,
+      'nexus_work_recurse'    => true,
+      # Assume a good revision as init.pp screens for us
+      'revision'              => '01',
+      'version'               => '2.11.2',
+    }
+  }
+
+  context 'no params set' do
+    let(:params) {{}}
+
+    it 'should fail' do
+      expect { should compile }.to raise_error(RSpec::Expectations::ExpectationNotMetError,
+              /Must pass /)
+    end
+  end
+
+  context 'with default values' do
+    it { should contain_class('nexus::package') }
+
+    it { should contain_wget__fetch('nexus-2.11.2-01-bundle.tar.gz').with(
+      'source'      => 'http://download.sonatype.com/nexus/oss/nexus-2.11.2-01-bundle.tar.gz',
+      'destination' => '/srv/nexus-2.11.2-01-bundle.tar.gz',
+      'before'      => 'Exec[nexus-untar]',
+    ) }
+
+    it { should contain_exec('nexus-untar').with(
+      'command' => 'tar zxf /srv/nexus-2.11.2-01-bundle.tar.gz',
+      'cwd'     => '/srv',
+      'creates' => '/srv/nexus-2.11.2-01',
+      'path'    => [ '/bin', '/usr/bin' ],
+    ) }
+
+    it { should contain_file('/srv/nexus-2.11.2-01').with(
+      'ensure'  => 'directory',
+      'owner'   => 'nexus',
+      'group'   => 'nexus',
+      'recurse' => true,
+      'require' => 'Exec[nexus-untar]',
+    ) }
+
+    it { should contain_file('/srv/sonatype-work/nexus').with(
+      'ensure'  => 'directory',
+      'owner'   => 'nexus',
+      'group'   => 'nexus',
+      'recurse' => true,
+      'require' => 'Exec[nexus-untar]',
+    ) }
+
+    it { should contain_file('/srv/nexus').with(
+      'ensure'  => 'link',
+      'target'  => '/srv/nexus-2.11.2-01',
+      'require' => 'Exec[nexus-untar]',
+    ) }
+
+    it 'should handle deploy_true' do
+      params.merge!(
+        {
+          'deploy_pro'    => true,
+          'download_site' => 'http://download.sonatype.com/nexus/professional-bundle',
+        }
+      )
+
+      should contain_wget__fetch('nexus-professional-2.11.2-01-bundle.tar.gz').with(
+        'source' => 'http://download.sonatype.com/nexus/professional-bundle/nexus-professional-2.11.2-01-bundle.tar.gz',
+        'destination' => '/srv/nexus-professional-2.11.2-01-bundle.tar.gz',
+      )
+
+      should contain_exec('nexus-untar').with(
+        'command' => 'tar zxf /srv/nexus-professional-2.11.2-01-bundle.tar.gz',
+        'creates' => '/srv/nexus-professional-2.11.2-01',
+      )
+
+      should contain_file('/srv/nexus-professional-2.11.2-01')
+
+      should contain_file('/srv/nexus').with(
+        'target' => '/srv/nexus-professional-2.11.2-01',
+      )
+    end
+  end
+end
+
+# vim: sw=2 ts=2 sts=2 et :


### PR DESCRIPTION
Add in the ability to deploy a Nexus Professional system by just setting
a single boolean (default false: aka deploy Nexus OSS) to true.

This adds in base rspec tests for the nexus::package class as well as
tests needed to validate that setting deploy_pro does the correct thing.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>