### PR TITLE
Add nexus_selinux_ignore_defaults to prevent enforcing SELinux owners…

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -81,11 +81,12 @@ class nexus::package (
   # under the application.  This is why we do not make recursing optional
   # for this resource but do for $nexus_work_dir.
   file{ $nexus_home_real:
-    ensure  => directory,
-    owner   => $nexus_user,
-    group   => $nexus_group,
-    recurse => true,
-    require => Exec[ 'nexus-untar']
+    ensure                  => directory,
+    owner                   => $nexus_user,
+    group                   => $nexus_group,
+    recurse                 => true,
+    selinux_ignore_defaults => $nexus_selinux_ignore_defaults,
+    require                 => Exec[ 'nexus-untar']
   }
 
 
@@ -93,11 +94,12 @@ class nexus::package (
   # creates this and results in a duplicate resource. -tmclaughlin
   if $nexus_work_dir_manage == true {
     file{ $nexus_work_dir:
-      ensure  => directory,
-      owner   => $nexus_user,
-      group   => $nexus_group,
-      recurse => $nexus_work_recurse,
-      require => Exec[ 'nexus-untar']
+      ensure                  => directory,
+      owner                   => $nexus_user,
+      group                   => $nexus_group,
+      recurse                 => $nexus_work_recurse,
+      selinux_ignore_defaults => $nexus_selinux_ignore_defaults,
+      require                 => Exec[ 'nexus-untar']
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,19 +21,20 @@
 #
 class nexus::params {
   # See nexus::package on why this won't increment the package version.
-  $version               = 'latest'
-  $revision              = '01'
-  $deploy_pro            = false
-  $download_site         = 'http://download.sonatype.com/nexus/oss'
-  $nexus_root            = '/srv'
-  $nexus_home_dir        = 'nexus'
-  $nexus_work_recurse    = true
-  $nexus_work_dir_manage = true
-  $nexus_user            = 'nexus'
-  $nexus_group           = 'nexus'
-  $nexus_host            = '0.0.0.0'
-  $nexus_port            = '8081'
-  $nexus_context         = '/nexus'
-  $nexus_manage_user     = true
-  $pro_download_site     = 'http://download.sonatype.com/nexus/professional-bundle'
+  $version                       = 'latest'
+  $revision                      = '01'
+  $deploy_pro                    = false
+  $download_site                 = 'http://download.sonatype.com/nexus/oss'
+  $nexus_root                    = '/srv'
+  $nexus_home_dir                = 'nexus'
+  $nexus_work_recurse            = true
+  $nexus_work_dir_manage         = true
+  $nexus_selinux_ignore_defaults = true
+  $nexus_user                    = 'nexus'
+  $nexus_group                   = 'nexus'
+  $nexus_host                    = '0.0.0.0'
+  $nexus_port                    = '8081'
+  $nexus_context                 = '/nexus'
+  $nexus_manage_user             = true
+  $pro_download_site             = 'http://download.sonatype.com/nexus/professional-bundle'
 }


### PR DESCRIPTION
This fix is to prevent circular update of SELinux file ownership for managed nexus_work_dir. It can lead to memory starvation while dealing with very large work dir. 