### PR TITLE
Remove multi inheritance

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -25,7 +25,7 @@ class nexus::config(
   $nexus_port,
   $nexus_context,
   $nexus_work_dir,
-) inherits nexus::params {
+) {
 
   $nexus_properties_file = "${nexus_root}/${nexus_home_dir}/conf/nexus.properties"
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,12 +19,12 @@
 # Copyright 2013 Hubspot
 #
 class nexus::config(
-  $nexus_root,
-  $nexus_home_dir,
-  $nexus_host,
-  $nexus_port,
-  $nexus_context,
-  $nexus_work_dir,
+  $nexus_root = $::nexus::nexus_root,
+  $nexus_home_dir = $::nexus::nexus_home_dir,
+  $nexus_host = $::nexus::nexus_host,
+  $nexus_port = $::nexus::nexus_port,
+  $nexus_context = $::nexus::nexus_context,
+  $nexus_work_dir = $::nexus::nexus_work_dir,
 ) {
 
   $nexus_properties_file = "${nexus_root}/${nexus_home_dir}/conf/nexus.properties"
@@ -46,7 +46,7 @@ class nexus::config(
     match => '^nexus-webapp-context-path',
     line  => "nexus-webapp-context-path=${nexus_context}"
   }
-  
+
   file_line{ 'nexus-work':
     path  => $nexus_properties_file,
     match => '^nexus-work',

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -39,7 +39,7 @@ class nexus::package (
   $nexus_work_dir,
   $nexus_work_dir_manage,
   $nexus_work_recurse,
-) inherits nexus::params {
+) {
 
   $nexus_home      = "${nexus_root}/${nexus_home_dir}"
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -28,17 +28,18 @@
 # Copyright 2013 Hubspot
 #
 class nexus::package (
-  $version,
-  $revision,
-  $deploy_pro,
-  $download_site,
-  $nexus_root,
-  $nexus_home_dir,
-  $nexus_user,
-  $nexus_group,
-  $nexus_work_dir,
-  $nexus_work_dir_manage,
-  $nexus_work_recurse,
+  $version = $::nexus::version,
+  $revision = $::nexus::revision,
+  $deploy_pro = $::nexus::deploy_pro,
+  $download_site = $::nexus::download_site,
+  $nexus_root = $::nexus::nexus_root,
+  $nexus_home_dir = $::nexus::nexus_home_dir,
+  $nexus_user = $::nexus::nexus_user,
+  $nexus_group = $::nexus::nexus_group,
+  $nexus_work_dir = $::nexus::nexus_work_dir,
+  $nexus_work_dir_manage = $::nexus::nexus_work_dir_manage,
+  $nexus_work_recurse = $::nexus::nexus_work_recurse,
+  $nexus_selinux_ignore_defaults = $::nexus::nexus_selinux_ignore_defaults,
 ) {
 
   $nexus_home      = "${nexus_root}/${nexus_home_dir}"

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -8,7 +8,7 @@
 #
 # === Variables
 #
-# [*nexus_home*] 
+# [*nexus_home*]
 #   The home location for the service
 #
 # [*nexus_user*]
@@ -34,9 +34,9 @@
 # Copyright 2013 Hubspot
 #
 class nexus::service (
-  $nexus_home,
-  $nexus_user,
-  $version
+  $nexus_home = $::nexus::nexus_home,
+  $nexus_user = $::nexus::nexus_user,
+  $version = $::nexus::version,
 ) {
   $nexus_script = "${nexus_home}/bin/nexus"
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -12,15 +12,6 @@ describe 'nexus::config', :type => :class do
     }
   }
 
-  context 'no params set' do
-    let(:params) {{}}
-
-    it 'should fail' do
-      expect { should compile }.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-              /Must pass /)
-    end
-  end
-
   context 'with test values' do
     it { should contain_class('nexus::config') }
 

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -18,15 +18,6 @@ describe 'nexus::package', :type => :class do
     }
   }
 
-  context 'no params set' do
-    let(:params) {{}}
-
-    it 'should fail' do
-      expect { should compile }.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-              /Must pass /)
-    end
-  end
-
   context 'with default values' do
     it { should contain_class('nexus::package') }
 

--- a/spec/classes/service_spec.rb
+++ b/spec/classes/service_spec.rb
@@ -9,15 +9,6 @@ describe 'nexus::service', :type => :class do
     }
   }
 
-  context 'no params set' do
-    let(:params) {{}}
-
-    it 'should fail' do
-      expect { should compile }.to raise_error(RSpec::Expectations::ExpectationNotMetError,
-              /Must pass nexus_home/)
-    end
-  end
-
   context 'with test values' do
     it { should contain_class('nexus::service') }
 


### PR DESCRIPTION
Mutli level inheritance is not recomended, and it's benefits can be accomplished without inheritance.

See https://docs.puppetlabs.com/puppet/latest/reference/lang_classes.html#inheritance for more information