### PR TITLE
Adds new download_folder parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,7 @@ class nexus (
   $nexus_work_recurse    = $nexus::params::nexus_work_recurse,
   $nexus_context         = $nexus::params::nexus_context,
   $nexus_manage_user     = $nexus::params::nexus_manage_user,
+  $download_folder       = $nexus::params::download_folder,
 ) inherits nexus::params {
   include stdlib
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -40,6 +40,7 @@ class nexus::package (
   $nexus_work_dir_manage = $::nexus::nexus_work_dir_manage,
   $nexus_work_recurse = $::nexus::nexus_work_recurse,
   $nexus_selinux_ignore_defaults = $::nexus::nexus_selinux_ignore_defaults,
+  $download_folder = $::nexus::download_folder,
 ) {
 
   $nexus_home      = "${nexus_root}/${nexus_home_dir}"
@@ -54,7 +55,7 @@ class nexus::package (
 
   $nexus_archive   = "nexus${bundle_type}-${full_version}-bundle.tar.gz"
   $download_url    = "${download_site}/${nexus_archive}"
-  $dl_file         = "${nexus_root}/${nexus_archive}"
+  $dl_file         = "${download_folder}/${nexus_archive}"
   $nexus_home_real = "${nexus_root}/nexus${bundle_type}-${full_version}"
 
   # NOTE: When setting version to 'latest' the site redirects to the latest
@@ -72,8 +73,7 @@ class nexus::package (
   }
 
   exec{ 'nexus-untar':
-    command => "tar zxf ${dl_file}",
-    cwd     => $nexus_root,
+    command => "tar zxf ${download_folder}/${nexus_archive} --directory ${nexus_root}",
     creates => $nexus_home_real,
     path    => ['/bin','/usr/bin'],
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,4 +37,5 @@ class nexus::params {
   $nexus_context                 = '/nexus'
   $nexus_manage_user             = true
   $pro_download_site             = 'http://download.sonatype.com/nexus/professional-bundle'
+  $download_folder               = '/srv'
 }

--- a/spec/acceptance/download_folder_spec.rb
+++ b/spec/acceptance/download_folder_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper_acceptance'
+
+describe 'nexus class' do
+
+  context 'download folder parameter' do
+    # Using puppet_apply as a helper
+    it 'should work with no errors' do
+      pp = <<-EOS
+      class{ '::java': }
+
+      class{ '::nexus':
+        version    => '2.8.0',
+        revision   => '05',
+        nexus_root => '/srv',
+        download_folder => '/var/tmp/'
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe user('nexus') do
+      it { should belong_to_group 'nexus' }
+    end
+
+    describe service('nexus') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+
+    context 'Nexus should be running on the default port' do
+      describe command('sleep 30 && echo "Give Nexus time to start"') do
+        its(:exit_status) { should eq 0 }
+      end
+      describe command('curl 0.0.0.0:8081/nexus/') do
+        its(:stdout) { should match /Sonatype Nexus&trade; 2.8.0-05/ }
+      end
+    end
+
+  end
+end

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -15,6 +15,7 @@ describe 'nexus::package', :type => :class do
       # Assume a good revision as init.pp screens for us
       'revision'              => '01',
       'version'               => '2.11.2',
+      'download_folder'       => '/srv',
     }
   }
 
@@ -28,8 +29,7 @@ describe 'nexus::package', :type => :class do
     ) }
 
     it { should contain_exec('nexus-untar').with(
-      'command' => 'tar zxf /srv/nexus-2.11.2-01-bundle.tar.gz',
-      'cwd'     => '/srv',
+      'command' => 'tar zxf /srv/nexus-2.11.2-01-bundle.tar.gz --directory /srv',
       'creates' => '/srv/nexus-2.11.2-01',
       'path'    => [ '/bin', '/usr/bin' ],
     ) }
@@ -70,7 +70,7 @@ describe 'nexus::package', :type => :class do
       )
 
       should contain_exec('nexus-untar').with(
-        'command' => 'tar zxf /srv/nexus-professional-2.11.2-01-bundle.tar.gz',
+        'command' => 'tar zxf /srv/nexus-professional-2.11.2-01-bundle.tar.gz --directory /srv',
         'creates' => '/srv/nexus-professional-2.11.2-01',
       )
 


### PR DESCRIPTION
Allows the user to choose a different folder to download files to, such as a mounted drive.

Previous behavior remains the same, as it downloads to /srv/ location by default.