### PR TITLE
Fix dependency issue

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,5 +131,5 @@ class nexus (
     version    => $version,
   }
 
-  anchor{ 'nexus::setup': }
+  anchor{ 'nexus::setup': } -> Class['nexus::package'] -> Class['nexus::config'] -> Class['nexus::Service'] -> anchor { 'nexus::done': }
 }


### PR DESCRIPTION
When applied with Puppet 4.5.2, an initial deployment results in these errors:
```
Error: /Stage[main]/Nexus::Config/File_line[nexus-application-host]: Could not evaluate: No such file or directory @ rb_sysopen - /opt/nexus/current/etc/org.sonatype.nexus.cfg
Error: /Stage[main]/Nexus::Config/File_line[nexus-application-port]: Could not evaluate: No such file or directory @ rb_sysopen - /opt/nexus/current/etc/org.sonatype.nexus.cfg
Error: /Stage[main]/Nexus::Config/File_line[nexus-webapp-context-path]: Could not evaluate: No such file or directory @ rb_sysopen - /opt/nexus/current/etc/org.sonatype.nexus.cfg
Error: /Stage[main]/Nexus::Config/File_line[nexus-work]: Could not evaluate: No such file or directory @ rb_sysopen - /opt/nexus/current/etc/org.sonatype.nexus.cfg
Warning: /Stage[main]/Nexus::Service/File[/lib/systemd/system/nexus.service]: Skipping because of failed dependencies
Warning: /Stage[main]/Nexus::Service/Service[nexus]: Skipping because of failed dependencies
```
This is because the Nexus::Package class hasn't been applied yet so there is no `/opt/nexus/current` etc directory.

This commit will fix the usage of the `anchor` pattern.