### PR TITLE
Support older versions of Ubuntu which do not use systemd by default

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -41,7 +41,8 @@ class nexus::service (
 ) {
   $nexus_script = "${nexus_home}/bin/nexus"
 
-  if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8.0') > 0) or $::operatingsystem == 'Ubuntu' {
+  if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8.0') > 0) or
+     ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') > 0) {
     file { '/lib/systemd/system/nexus.service':
       mode    => '0644',
       owner   => 'root',


### PR DESCRIPTION
Tested on Ubuntu 14.04LTS. Should fall back to using the init style service resource on versions of Ubuntu < 15.04.