### PR TITLE
FIX #51 possibility to add checksum

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,7 @@ class nexus (
   $nexus_data_folder     = $nexus::params::nexus_data_folder,
   $download_folder       = $nexus::params::download_folder,
   $manage_config         = $nexus::params::manage_config,
+  $md5sum                = $nexus::params::md5sum,
 ) inherits nexus::params {
   include stdlib
 
@@ -108,6 +109,7 @@ class nexus (
     nexus_work_dir        => $real_nexus_work_dir,
     nexus_work_dir_manage => $nexus_work_dir_manage,
     nexus_work_recurse    => $nexus_work_recurse,
+    md5sum                => $md5sum,
     notify                => Class['nexus::service']
   }
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -42,6 +42,7 @@ class nexus::package (
   $nexus_work_recurse = $::nexus::nexus_work_recurse,
   $nexus_selinux_ignore_defaults = $::nexus::nexus_selinux_ignore_defaults,
   $download_folder = $::nexus::download_folder,
+  $md5sum = $::nexus::md5sum,
 ) {
 
   $nexus_home      = "${nexus_root}/${nexus_home_dir}"
@@ -70,6 +71,7 @@ class nexus::package (
   wget::fetch{ $nexus_archive:
     source      => $download_url,
     destination => $dl_file,
+    source_hash => $md5sum,
     before      => Exec['nexus-untar'],
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,5 +41,5 @@ class nexus::params {
   $nexus_data_folder             = undef
   $download_folder               = '/srv'
   $manage_config                 = true
-  $md5sum                        = ''
+  $md5sum                        = undef
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,4 +41,5 @@ class nexus::params {
   $nexus_data_folder             = undef
   $download_folder               = '/srv'
   $manage_config                 = true
+  $md5sum                        = ''
 }

--- a/spec/acceptance/checksum_spec.rb
+++ b/spec/acceptance/checksum_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper_acceptance'
+
+describe 'apt class' do
+
+  context 'default parameters' do
+    # Using puppet_apply as a helper
+    it 'should work with no errors' do
+      pp = <<-EOS
+      class{ '::java': }
+
+      class{ '::nexus':
+        version               => '2.8.0',
+        revision              => '05',
+        md5sum                => 'e1cece1ae5eb3a12f857e2368a3e9dbc',
+        nexus_root => '/srv',
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_failures => true)
+    end
+
+    describe user('nexus') do
+      it { should belong_to_group 'nexus' }
+    end
+
+    describe service('nexus') do
+      it { is_expected.to be_enabled }
+      it { is_expected.to be_running }
+    end
+
+    context 'Nexus should be running on the default port' do
+      describe port(8081) do
+        it {
+          sleep(180) # Waiting start up
+          should be_listening
+        }
+      end
+
+      describe command('curl 0.0.0.0:8081/nexus/') do
+        its(:stdout) { should match /Sonatype Nexus&trade; 2.8.0-05/ }
+      end
+    end
+
+  end
+end

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -24,6 +24,7 @@ describe 'nexus::package', :type => :class do
           'revision'                      => '01',
           'version'                       => '2.11.2',
           'download_folder'               => '/srv',
+          'md5sum'                        => '',
         }
       }
 
@@ -34,6 +35,7 @@ describe 'nexus::package', :type => :class do
           'source'      => 'http://download.sonatype.com/nexus/oss/nexus-2.11.2-01-bundle.tar.gz',
           'destination' => '/srv/nexus-2.11.2-01-bundle.tar.gz',
           'before'      => 'Exec[nexus-untar]',
+          'source_hash' => '',
         ) }
 
         it { should contain_exec('nexus-untar').with(
@@ -68,7 +70,7 @@ describe 'nexus::package', :type => :class do
           params.merge!(
             {
               'deploy_pro'    => true,
-              'download_site' => 'http://download.sonatype.com/nexus/professional-bundle',
+              'download_site' => 'http://download.sonatype.com/nexus/professional-bundle'
             }
           )
 
@@ -88,7 +90,28 @@ describe 'nexus::package', :type => :class do
             'target' => '/srv/nexus-professional-2.11.2-01',
           )
         end
+
+        it 'should working with md5sum' do
+          params.merge!(
+            {
+              'md5sum'        => '1234567890'
+            }
+          )
+          should contain_wget__fetch('nexus-2.11.2-01-bundle.tar.gz').with(
+            'source'      => 'http://download.sonatype.com/nexus/oss/nexus-2.11.2-01-bundle.tar.gz',
+            'destination' => '/srv/nexus-2.11.2-01-bundle.tar.gz',
+            'before'      => 'Exec[nexus-untar]',
+            'source_hash' => '1234567890',
+          )
+          should contain_exec('nexus-untar').with(
+            'command' => 'tar zxf /srv/nexus-2.11.2-01-bundle.tar.gz --directory /srv',
+            'creates' => '/srv/nexus-2.11.2-01',
+            'path'    => [ '/bin', '/usr/bin' ],
+          )
+        end
+
       end
+
     end
   end
 end

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -24,6 +24,7 @@ describe 'nexus::package', :type => :class do
           'revision'                      => '01',
           'version'                       => '2.11.2',
           'download_folder'               => '/srv',
+          'md5sum'                        => '',
         }
       }
 
@@ -34,7 +35,7 @@ describe 'nexus::package', :type => :class do
           'source'      => 'http://download.sonatype.com/nexus/oss/nexus-2.11.2-01-bundle.tar.gz',
           'destination' => '/srv/nexus-2.11.2-01-bundle.tar.gz',
           'before'      => 'Exec[nexus-untar]',
-          'source_hash' => nil,
+          'source_hash' => '',
         ) }
 
         it { should contain_exec('nexus-untar').with(

--- a/spec/classes/package_spec.rb
+++ b/spec/classes/package_spec.rb
@@ -24,7 +24,6 @@ describe 'nexus::package', :type => :class do
           'revision'                      => '01',
           'version'                       => '2.11.2',
           'download_folder'               => '/srv',
-          'md5sum'                        => '',
         }
       }
 
@@ -35,7 +34,7 @@ describe 'nexus::package', :type => :class do
           'source'      => 'http://download.sonatype.com/nexus/oss/nexus-2.11.2-01-bundle.tar.gz',
           'destination' => '/srv/nexus-2.11.2-01-bundle.tar.gz',
           'before'      => 'Exec[nexus-untar]',
-          'source_hash' => '',
+          'source_hash' => nil,
         ) }
 
         it { should contain_exec('nexus-untar').with(


### PR DESCRIPTION
New feature to set the checksum.

To use  you must use the optional parameter `md5sum`
For example

``` puppet
class{ '::nexus':
        version               => '3.0.2',
        revision              => '02',
        download_site         => 'http://download.sonatype.com/nexus/3',
        nexus_type            => 'unix',
        md5sum                => '73425709c2c73f368655d32a2c757b24',
        nexus_work_dir_manage => false,
      }
```
