### PR TITLE
Fix nexus config path and that the file exists

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,13 +29,26 @@ class nexus::config(
   $version = $::nexus::version,
 ) {
 
-  if $version !~ /\d.*/ or versioncmp($version, '3.0.0') >= 0 {
+  if $version !~ /\d.*/ or versioncmp($version, '3.1.0') >= 0 {
+    # Per the Sonatype documentation the custom nexus properties file is
+    # {karaf.data}/etc/nexus.properties where {karaf.data} is the work dir
+    $conf_path = 'etc/nexus.properties'
+    $nexus_properties_file = "${nexus_work_dir}/${conf_path}"
+  }
+  elsif versioncmp($version, '3.0.0') >= 0 {
     $conf_path = 'etc/org.sonatype.nexus.cfg'
+    $nexus_properties_file = "${nexus_root}/${nexus_home_dir}/${conf_path}"
   } else {
     $conf_path = 'conf/nexus.properties'
+    $nexus_properties_file = "${nexus_root}/${nexus_home_dir}/${conf_path}"
   }
-  $nexus_properties_file = "${nexus_root}/${nexus_home_dir}/${conf_path}"
   $nexus_data_dir = "${nexus_root}/${nexus_home_dir}/data"
+
+  # Nexus >=3.x do no necesarily have a properties file in place to
+  # modify. Make sure that there is at least a minmal file there
+  file { $nexus_properties_file:
+    ensure =>  present,
+  }
 
   file_line{ 'nexus-application-host':
     path  => $nexus_properties_file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,7 +61,11 @@ class nexus (
   if $nexus_work_dir != undef {
     $real_nexus_work_dir = $nexus_work_dir
   } else {
-    $real_nexus_work_dir = "${nexus_root}/sonatype-work/nexus"
+    if $version !~ /\d.*/ or versioncmp($version, '3.1.0') >= 0 {
+      $real_nexus_work_dir = "${nexus_root}/sonatype-work/nexus3"
+    } else {
+      $real_nexus_work_dir = "${nexus_root}/sonatype-work/nexus"
+    }
   }
 
   # Determine if Nexus Pro should be deployed instead of OSS

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -105,6 +105,17 @@ class nexus::package (
       selinux_ignore_defaults => $nexus_selinux_ignore_defaults,
       require                 => Exec[ 'nexus-untar']
     }
+
+    # Nexus 3 needs to have a nexus_work_dir/etc for the properties file
+    if $version !~ /\d.*/ or versioncmp($version, '3.1.0') >= 0 {
+      file { "${nexus_work_dir}/etc":
+        ensure                  => directory,
+        owner                   => $nexus_user,
+        group                   => $nexus_group,
+        recurse                 => $nexus_work_recurse,
+        selinux_ignore_defaults => $nexus_selinux_ignore_defaults,
+      }
+    }
   }
 
   file{ $nexus_home:


### PR DESCRIPTION
Nexus uses different configuration files for v2.x, 3.0.x and >3.1.0

Additionally, the configuration file may not exist on a >3.x
installation which will cause failures unless a minimal file is created

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>