### PR TITLE
Fix file limit for Nexus 3 deployments

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -49,8 +49,8 @@ class nexus::service (
       owner   => 'root',
       group   => 'root',
       content => template('nexus/nexus.systemd.erb'),
-    } ->
-    service { 'nexus':
+    }
+    -> service { 'nexus':
       ensure => running,
       name   => 'nexus',
       enable => true,

--- a/templates/nexus.systemd.erb
+++ b/templates/nexus.systemd.erb
@@ -4,6 +4,7 @@ After=network.target
 
 [Service]
 Type=forking
+LimitNOFILE=65536
 ExecStart=<%= scope.lookupvar('nexus::service::nexus_script') %> start
 ExecStop=<%= scope.lookupvar('nexus::service::nexus_script') %> stop
 User=<%= scope.lookupvar('nexus::service::nexus_user') %>


### PR DESCRIPTION
The release of Nexus 3.4.0 includes a statement that the file descriptor
limit for Nexus 3 needs to be set to 65536. Future revisions fo Nexus 3
will likely fail to start if the descriptor is less than this.

Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>