### PR TITLE
Bugfix: manage homeDir through puppet + define homeDir as /home/nexus

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,11 +90,13 @@ class nexus (
       ensure  => present
     }
 
+    $my_nexus_home = "/home/${nexus_user}"
     user { $nexus_user:
       ensure  => present,
       comment => 'Nexus User',
       gid     => $nexus_group,
-      home    => $nexus_root,
+      home    => "$my_nexus_home",
+      managehome => true,
       shell   => '/bin/sh', # required to start application via script.
       system  => true,
       require => Group[$nexus_group]


### PR DESCRIPTION
I thought it would be better to manage nexus' home directory through puppet.

Switched home directory from $my_nexus_root to /home/nexus because of the following error message:
**tail -f /srv/sonatype-work/nexus3/log/nexus.log**
> Couldn't flush user prefs: java.util.prefs.BackingStoreException: Couldn't get file lock.

Otherwise nexus 3.1 wouln't start up.

This pull request fixes https://github.com/hubspotdevops/puppet-nexus/issues/97