### PR TITLE
Ensure 'etc' directory exists

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,13 +32,16 @@ class nexus::config(
   if $version !~ /\d.*/ or versioncmp($version, '3.1.0') >= 0 {
     # Per the Sonatype documentation the custom nexus properties file is
     # {karaf.data}/etc/nexus.properties where {karaf.data} is the work dir
+    $conf_dir = "${nexus_work_dir}/etc"
     $conf_path = 'etc/nexus.properties'
     $nexus_properties_file = "${nexus_work_dir}/${conf_path}"
   }
   elsif versioncmp($version, '3.0.0') >= 0 {
+    $conf_dir = "${nexus_root}/${nexus_home_dir}/etc"
     $conf_path = 'etc/org.sonatype.nexus.cfg'
     $nexus_properties_file = "${nexus_root}/${nexus_home_dir}/${conf_path}"
   } else {
+    $conf_dir = "${nexus_root}/${nexus_home_dir}/etc"
     $conf_path = 'conf/nexus.properties'
     $nexus_properties_file = "${nexus_root}/${nexus_home_dir}/${conf_path}"
   }
@@ -46,6 +49,10 @@ class nexus::config(
 
   # Nexus >=3.x do no necesarily have a properties file in place to
   # modify. Make sure that there is at least a minmal file there
+  file { $conf_dir:
+    ensure =>  directory,
+  }
+
   file { $nexus_properties_file:
     ensure =>  present,
   }


### PR DESCRIPTION
resolves following issue with nexus version 3.6.0 ->
Error: Could not set 'present' on ensure: No such file or directory @ rb_sysopen - /srv/sonatype-work/nexus3/etc/nexus.properties at /etc/puppetlabs/code/environments/production/modules/nexus/manifests/config.pp:49