### PR TITLE
adding OracleLinux as an options for systemd script

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -43,7 +43,7 @@ class nexus::service (
 
   if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8.0') > 0) or
   ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') > 0) or
-  (($::operatingsystem == 'CentOS' or $::operatingsystem == 'RedHat') and versioncmp($::operatingsystemmajrelease, '7') >= 0) {
+  (($::operatingsystem == 'CentOS' or $::operatingsystem == 'RedHat' or $::operatingsystem == 'OracleLinux') and versioncmp($::operatingsystemmajrelease, '7') >= 0) {
     file { '/lib/systemd/system/nexus.service':
       mode    => '0644',
       owner   => 'root',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "hubspot-nexus",
-  "version": "1.7.3",
+  "version": "1.7.3.1",
   "source": "http://github.com/hubspotdevops/puppet-nexus",
   "author": "Tom McLaughlin <tmclaughlin@hubspot.com>",
   "license": "MIT",


### PR DESCRIPTION
To allow setting up of systemd script when using Oracle Linux version of Red Hat.