### PR TITLE
Added the ability to configure JVM options (i.e. setting memory heap size)

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -75,7 +75,7 @@ class nexus::config(
     line  => "nexus-work=${nexus_work_dir}"
   }
 
-  if $vmoptions {
+  if ! empty($vmoptions) {
     create_resources(file_line, $vmoptions, { path => "${nexus_root}/${nexus_home_dir}/bin/nexus.vmoptions" })
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -75,7 +75,7 @@ class nexus::config(
     line  => "nexus-work=${nexus_work_dir}"
   }
 
-  if ! empty($vmoptions) {
+  if !empty($vmoptions) {
     create_resources(file_line, $vmoptions, { path => "${nexus_root}/${nexus_home_dir}/bin/nexus.vmoptions" })
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -27,6 +27,7 @@ class nexus::config(
   $nexus_work_dir = $::nexus::nexus_work_dir,
   $nexus_data_folder = $::nexus::nexus_data_folder,
   $version = $::nexus::version,
+  $vmoptions = $::nexus::vmoptions,
 ) {
 
   if $version !~ /\d.*/ or versioncmp($version, '3.1.0') >= 0 {
@@ -72,6 +73,10 @@ class nexus::config(
     path  => $nexus_properties_file,
     match => '^nexus-work',
     line  => "nexus-work=${nexus_work_dir}"
+  }
+
+  if $vmoptions {
+    create_resources(file_line, $vmoptions, { path => "${nexus_root}/${nexus_home_dir}/bin/nexus.vmoptions" })
   }
 
   if $nexus_data_folder {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,7 @@ class nexus (
   $download_folder       = $nexus::params::download_folder,
   $manage_config         = $nexus::params::manage_config,
   $md5sum                = $nexus::params::md5sum,
+  $vmoptions             = $nexus::params::vmoptions,
 ) inherits nexus::params {
   include stdlib
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,5 +42,5 @@ class nexus::params {
   $download_folder               = '/srv'
   $manage_config                 = true
   $md5sum                        = undef
-  $vmoptions                     = undef
+  $vmoptions                     = {}
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,4 +42,5 @@ class nexus::params {
   $download_folder               = '/srv'
   $manage_config                 = true
   $md5sum                        = undef
+  $vmoptions                     = undef
 }

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -11,6 +11,7 @@ describe 'nexus::config', :type => :class do
       'nexus_work_dir'    => '/foom',
       'version'           => '2.11.2',
       'nexus_data_folder' => '',
+      'vmoptions'         => '',
     }
   }
 

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -11,7 +11,7 @@ describe 'nexus::config', :type => :class do
       'nexus_work_dir'    => '/foom',
       'version'           => '2.11.2',
       'nexus_data_folder' => '',
-      'vmoptions'         => '',
+      'vmoptions'         => {},
     }
   }
 


### PR DESCRIPTION
Currently, there is no way to configure JVM settings for Nexus with this module.

An update has been added to allow setting various JVM settings. Example hiera below:

```
nexus::vmoptions :
  jvm-xmx:
    match: '^-Xmx'
    line: '-Xmx2703M'
  jvm-xms:
    match: '^-Xms'
    line: '-Xms2703M'
  jvm-max-direct-memory-size:
    match: '^-XX:MaxDirectMemorySize'
    line: '-XX:MaxDirectMemorySize=2703M'
```

This effectively configures: `"${nexus_root}/${nexus_home_dir}/bin/nexus.vmoptions"` using `file_line` from the Puppet standard library.