### PR TITLE
Module is able to configure nexus.vmoptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ Gemfile.lock
 pkg
 spec/fixtures/
 .vagrant/
+.idea/
 log/
 vendor/
 bin/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Install and configure Sonatype Nexus.
 
 ## Requires
-* maestrodev/wget
+* puppet/wget
 * puppetlabs/stdlib
 
 ## Usage
@@ -43,9 +43,14 @@ class role_nexus_server {
     revision              => '03',
     download_site         => 'http://download.sonatype.com/nexus/3',
     nexus_type            => 'unix',
-    nexus_work_dir_manage => false
+    nexus_work_dir_manage => false,
+    vmoptions             => {
+      "-Xms"                    => "1300M",
+      "-Xmx"                    => "1300M",
+      "-XX:MaxDirectMemorySize" => "3G",
+      "-XX:-OmitStackTraceInFastThrow" =>'-' # Options with '-' will be added to nexus.vmoptions without values
+    }
   }
-
 }
 ```
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -79,18 +79,17 @@ class nexus::config (
     $vmoptions.each | $key, $val | {
       notice "${key} is ${val}"
       $line = $val ? {
-        '-'     => "$key",
+        '-'     => $key,
         default => $key ? {
-          '-Xms' => "${key}${val}",
-          '-Xmx' => "${key}${val}",
-          default =>"${key}=${val}"
+          '-Xms'  => "${key}${val}",
+          '-Xmx'  => "${key}${val}",
+          default => "${key}=${val}"
         }
       }
       file_line { "${key}-${val}":
         path  => "${nexus_root}/${nexus_home_dir}/bin/nexus.vmoptions",
-        line  => "${line}",
+        line  => $line,
         match => "^${key}.*$",
-        # append_on_no_match => true,
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -131,11 +131,8 @@ class nexus (
       notify            => Class['nexus::service'],
       require           => Anchor['nexus::setup']
     }
-    anchor { 'nexus::setup': } ->
-    Class['nexus::package'] ->
-    Class['nexus::config'] ->
-    Class['nexus::Service'] ->
-    anchor { 'nexus::done': }
+    anchor { 'nexus::setup': } -> Class['nexus::package'] -> Class['nexus::config'] -> Class['nexus::Service'] -> anchor
+      { 'nexus::done': }
   }
 
   class { 'nexus::service':

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -34,16 +34,16 @@
 # Copyright 2013 Hubspot
 #
 class nexus::service (
-  $nexus_home = $::nexus::nexus_home,
-  $nexus_user = $::nexus::nexus_user,
+  $nexus_home  = $::nexus::nexus_home,
+  $nexus_user  = $::nexus::nexus_user,
   $nexus_group = $::nexus::nexus_group,
-  $version = $::nexus::version,
+  $version     = $::nexus::version,
 ) {
   $nexus_script = "${nexus_home}/bin/nexus"
-  notice "Operating system is ${::operatingsystem}. Relase ${operatingsystemmajrelease}"
   if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8.0') > 0) or
-  ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') > 0) or
-  (($::operatingsystem == 'CentOS' or $::operatingsystem == 'RedHat' or $::operatingsystem == 'OracleLinux') and versioncmp($::operatingsystemmajrelease, '7') >= 0) {
+    ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') > 0) or
+    (($::operatingsystem == 'CentOS' or $::operatingsystem == 'RedHat' or $::operatingsystem == 'OracleLinux') and
+      versioncmp($::operatingsystemmajrelease, '7') >= 0) {
     file { '/lib/systemd/system/nexus.service':
       mode    => '0644',
       owner   => 'root',
@@ -58,13 +58,13 @@ class nexus::service (
 
   } else {
 
-    file_line{ 'nexus_NEXUS_HOME':
+    file_line { 'nexus_NEXUS_HOME':
       path  => $nexus_script,
       match => '^#?NEXUS_HOME=',
       line  => "NEXUS_HOME=${nexus_home}",
     }
 
-    file{ '/etc/init.d/nexus':
+    file { '/etc/init.d/nexus':
       ensure  => 'link',
       target  => $nexus_script,
       require => [
@@ -77,7 +77,7 @@ class nexus::service (
     if $version !~ /\d.*/ or versioncmp($version, '3.0.0') >= 0 {
       $status_line = "env run_as_user=${nexus_user} /etc/init.d/nexus status"
 
-      file_line{ 'nexus_RUN_AS_USER':
+      file_line { 'nexus_RUN_AS_USER':
         path  => $nexus_script,
         match => '^run_as_user\=',
         line  => "run_as_user=\${run_as_user:-${nexus_user}}",
@@ -86,20 +86,20 @@ class nexus::service (
     } else {
       $status_line = 'env run_as_user=root /etc/init.d/nexus status'
 
-      file_line{ 'nexus_RUN_AS_USER':
+      file_line { 'nexus_RUN_AS_USER':
         path  => $nexus_script,
         match => '^#?RUN_AS_USER=',
         line  => "RUN_AS_USER=\${run_as_user:-${nexus_user}}",
       }
     }
 
-    service{ 'nexus':
+    service { 'nexus':
       ensure  => running,
       enable  => true,
       status  => $status_line,
       require => [File['/etc/init.d/nexus'],
         File_line['nexus_NEXUS_HOME'],
-        File_line['nexus_RUN_AS_USER'],]
+        File_line['nexus_RUN_AS_USER'], ]
     }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -40,10 +40,10 @@ class nexus::service (
   $version = $::nexus::version,
 ) {
   $nexus_script = "${nexus_home}/bin/nexus"
-
+  notice "Operating system is ${::operatingsystem}. Relase ${operatingsystemmajrelease}"
   if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemrelease, '8.0') > 0) or
   ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemrelease, '15.04') > 0) or
-  (($::operatingsystem == 'CentOS' or $::operatingsystem == 'RedHat') and versioncmp($::operatingsystemmajrelease, '7') >= 0) {
+  (($::operatingsystem == 'CentOS' or $::operatingsystem == 'RedHat' or $::operatingsystem == 'OracleLinux') and versioncmp($::operatingsystemmajrelease, '7') >= 0) {
     file { '/lib/systemd/system/nexus.service':
       mode    => '0644',
       owner   => 'root',

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -11,6 +11,7 @@ describe 'nexus::config', :type => :class do
       'nexus_work_dir'    => '/foom',
       'version'           => '2.11.2',
       'nexus_data_folder' => '',
+      'vmoptions' => '',
     }
   }
 


### PR DESCRIPTION
```
  class{ '::nexus':
    version               => '3.0.0',
    revision              => '03',
    download_site         => 'http://download.sonatype.com/nexus/3',
    nexus_type            => 'unix',
    nexus_work_dir_manage => false,
    vmoptions             => {
      "-Xms"                    => "1300M",
      "-Xmx"                    => "1300M",
      "-XX:MaxDirectMemorySize" => "3G",
      "-XX:-OmitStackTraceInFastThrow" =>'-' # Options with '-' will be added to nexus.vmoptions without values
    }
  }
```
**Hiera**
```
nexus::vmoptions:
  '-Xms': 1300M
  '-Xmx': 1300M
  '-XX:MaxDirectMemorySize': "3G"
  '-XX:-OmitStackTraceInFastThrow': '-'

```