### PR TITLE
Allow skipping nexus::package so people can use their own solution like pre-build binary packages

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,6 +107,7 @@ class nexus (
   }
 
   if $manage_package {
+
     class{ 'nexus::package':
       version               => $version,
       revision              => $revision,
@@ -125,6 +126,12 @@ class nexus (
   }
 
   if $manage_config {
+    if $manage_package {
+      $require_class = Class['nexus::package']
+    } else {
+      $require_class = undef
+    }
+
     class{ 'nexus::config':
       nexus_root        => $nexus_root,
       nexus_home_dir    => $nexus_home_dir,
@@ -133,8 +140,8 @@ class nexus (
       nexus_context     => $nexus_context,
       nexus_work_dir    => $real_nexus_work_dir,
       nexus_data_folder => $nexus_data_folder,
+      require           => $require_class,
       notify            => Class['nexus::service'],
-      require           => Anchor['nexus::setup']
     }
   }
 
@@ -144,5 +151,4 @@ class nexus (
     version    => $version,
   }
 
-  anchor{ 'nexus::setup': } -> Class['nexus::package'] -> Class['nexus::config'] -> Class['nexus::Service'] -> anchor { 'nexus::done': }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,10 @@
 #   The revision of the archive. This is needed for the name of the
 #   directory the archive is extracted to.  The default should suffice.
 #
+# [*manage_package*]
+#   Boolean that allows skipping the installation done in nexus::package
+#   This allows to implement your own installation, for example through pre-build packages
+#
 # [*nexus_root*]
 #   The root directory where the nexus application will live and tarballs
 #   will be downloaded to.
@@ -32,6 +36,7 @@
 class nexus (
   $version               = $nexus::params::version,
   $revision              = $nexus::params::revision,
+  $manage_package        = $nexus::params::manage_package,
   $deploy_pro            = $nexus::params::deploy_pro,
   $download_site         = $nexus::params::download_site,
   $nexus_type            = $nexus::params::type,
@@ -101,20 +106,22 @@ class nexus (
     }
   }
 
-  class{ 'nexus::package':
-    version               => $version,
-    revision              => $revision,
-    deploy_pro            => $deploy_pro,
-    download_site         => $real_download_site,
-    nexus_root            => $nexus_root,
-    nexus_home_dir        => $nexus_home_dir,
-    nexus_user            => $nexus_user,
-    nexus_group           => $nexus_group,
-    nexus_work_dir        => $real_nexus_work_dir,
-    nexus_work_dir_manage => $nexus_work_dir_manage,
-    nexus_work_recurse    => $nexus_work_recurse,
-    md5sum                => $md5sum,
-    notify                => Class['nexus::service']
+  if $manage_package {
+    class{ 'nexus::package':
+      version               => $version,
+      revision              => $revision,
+      deploy_pro            => $deploy_pro,
+      download_site         => $real_download_site,
+      nexus_root            => $nexus_root,
+      nexus_home_dir        => $nexus_home_dir,
+      nexus_user            => $nexus_user,
+      nexus_group           => $nexus_group,
+      nexus_work_dir        => $real_nexus_work_dir,
+      nexus_work_dir_manage => $nexus_work_dir_manage,
+      nexus_work_recurse    => $nexus_work_recurse,
+      md5sum                => $md5sum,
+      notify                => Class['nexus::service']
+    }
   }
 
   if $manage_config {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,6 +23,7 @@ class nexus::params {
   # See nexus::package on why this won't increment the package version.
   $version                       = 'latest'
   $revision                      = '01'
+  $manage_package                = true
   $type                          = 'bundle'
   $deploy_pro                    = false
   $download_site                 = 'http://download.sonatype.com/nexus/oss'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -40,15 +40,10 @@ describe 'nexus', :type => :class do
           'require' => 'Group[nexus]',
         ) }
 
-        it { should contain_anchor('nexus::setup') }
-        it { should contain_class('nexus::package').that_requires(
-          'Anchor[nexus::setup]' ) }
         it { should contain_class('nexus::config').that_requires(
           'Class[nexus::package]' ).that_notifies('Class[nexus::service]') }
         it { should contain_class('nexus::service').that_subscribes_to(
           'Class[nexus::config]' ) }
-        it { should contain_anchor('nexus::done').that_requires(
-          'Class[nexus::service]' ) }
 
         it 'should handle deploy_pro' do
           params.merge!(


### PR DESCRIPTION
We always package all our software to .deb's  and .rpm's. Therefor we would like to be able to skip nexus::package as a whole and implement our own installation from our profile.