### PR TITLE
maestrodev/wget was moved to vox pupuli

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Install and configure Sonatype Nexus.
 
 ## Requires
-* maestrodev/wget
+* puppet/wget
 * puppetlabs/stdlib
 
 ## Usage

--- a/metadata.json
+++ b/metadata.json
@@ -41,8 +41,8 @@
       "version_requirement": ">=0.0.0 <5.0.0"
     },
     {
-      "name": "maestrodev/wget",
-      "version_requirement": ">=1.0.0 <2.0.0"
+      "name": "puppet/wget",
+      "version_requirement": ">=1.0.0 <=2.0.1"
     }
   ]
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -23,7 +23,7 @@ RSpec.configure do |c|
       shell("/bin/touch #{default['puppetpath']}/hiera.yaml")
       shell('puppet module install puppetlabs-stdlib', { :acceptable_exit_codes => [0,1] })
       shell('puppet module install puppetlabs-java', { :acceptable_exit_codes => [0,1] })
-      shell('puppet module install maestrodev-wget', { :acceptable_exit_codes => [0,1] })
+      shell('puppet module install puppet-wget', { :acceptable_exit_codes => [0,1] })
     end
   end
 end


### PR DESCRIPTION
The maestro/wget module was moved to vox pupuli and is deprecated.

This PR is only to solve dependency tree view.